### PR TITLE
feat: 로그인 한 사용자 id 동적 할당

### DIFF
--- a/types/api/product.ts
+++ b/types/api/product.ts
@@ -25,6 +25,8 @@ export interface Product {
   subCategoryId?: string
   tags: string[]
   specifications?: Record<string, any>
+  sellerId?: number // 판매자 ID
+  sellerName?: string // 판매자 이름
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

1) 판매자 정보 하드코딩 제거
types/api/product.ts에 sellerId, sellerName 필드 추가
상품 상세에서 sellerId로 판매자 ID 사용
sellerName 없으면 "판매자"로 폴백
2) 카테고리 정보 하드코딩 제거
API 응답 카테고리 계층 정보 사용
breadcrumb/표시에 API 데이터 반영
3) 1:1 채팅 인증 로직 개선
localStorage.getItem("ohouse_user") 제거, useAuth().isAuthenticated 사용
alert 제거, toast로 메시지 표시

### 1:1 채팅하기 버튼을 누르면..!
이동 경로: /community/messages/${product.seller?.id} → app/community/messages/[userId]/page.tsx
동적 라우트: [userId] 슬롯에 product.seller?.id가 들어감

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #26 