### PR TITLE
feat: 쇼핑수다 게시판 무한 스크롤 및 홈페이지 인기 게시글 연동 구현

### DIFF
--- a/app/community/shopping-talk/page.tsx
+++ b/app/community/shopping-talk/page.tsx
@@ -1,35 +1,94 @@
 "use client"
 
+import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
-import { useCommunityPosts } from '@/lib/hooks/use-community'
+import { useInfiniteCommunityPosts } from '@/lib/hooks/use-community'
+import type { CommunityPost } from '@/types/api/community'
 import { formatRelativeTime } from '@/lib/utils'
+import { extractKeywords, getKeywordStyle } from '@/lib/utils/keyword-extractor'
 
-const categoryColors: Record<string, string> = {
-  추천: "bg-primary/10 text-primary",
-  질문: "bg-accent/10 text-accent",
-  정보: "bg-green-500/10 text-green-600",
-  후기: "bg-purple-500/10 text-purple-600",
+// 정렬 옵션 타입 정의
+type SortOption = {
+  label: string
+  sort: 'createdAt' | 'viewCount' | 'likeCount'
+  direction: 'asc' | 'desc'
 }
 
+// 정렬 옵션들
+const sortOptions: SortOption[] = [
+  { label: "최신순", sort: "createdAt", direction: "desc" },
+  { label: "조회수순", sort: "viewCount", direction: "desc" },
+  { label: "인기순", sort: "likeCount", direction: "desc" },
+]
+
+const categoryColors: Record<string, string> = {
+  추천: "bg-blue-600/15 text-blue-700 border border-blue-600/30",
+  질문: "bg-orange-500/15 text-orange-700 border border-orange-500/30",
+  정보: "bg-emerald-600/15 text-emerald-700 border border-emerald-600/30",
+  후기: "bg-violet-600/15 text-violet-700 border border-violet-600/30",
+}
+
+const mapPostToUI = (post: CommunityPost) => ({
+  id: post.postId,
+  title: post.title,
+  content: post.content,
+  author: post.authorName,
+  createdAt: formatRelativeTime(post.createdAt),
+  views: post.viewCount,
+  likes: post.likeCount,
+  comments: post.commentCount,
+  category: post.category,  // 카테고리 (백엔드에서 받아옴)
+  keywords: extractKeywords(post.title, post.content, 3),  // 제목과 내용에서 자동으로 키워드 추출
+  imagesUrl: post.imagesUrl,
+})
+
 export default function ShoppingTalkPage() {
-  const { data: postsData } = useCommunityPosts({
-    page: 0,
+  const [selectedSort, setSelectedSort] = useState<SortOption>(sortOptions[0]) // 기본값: 최신순
+  const observerTarget = useRef<HTMLDivElement>(null)
+
+  // 🔄 API에서 게시글 데이터 가져오기 (무한 스크롤)
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useInfiniteCommunityPosts({
     size: 10,
-    sort: 'createdAt',
-    direction: 'desc'
+    sort: selectedSort.sort,
+    direction: selectedSort.direction
   })
-  const talkPosts = postsData?.content.map(post => ({
-    id: post.postId,
-    category: "일반",
-    title: post.title,
-    content: post.content,
-    author: post.authorName,
-    createdAt: formatRelativeTime(post.createdAt),
-    views: post.viewCount,
-    likes: post.likeCount,
-    comments: post.commentCount,
-    imagesUrl: post.imagesUrl,
-  })) || []
+
+  // Intersection Observer를 사용한 무한 스크롤 구현
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          console.log('[무한스크롤] 다음 페이지 로딩 시작')
+          fetchNextPage()
+        }
+      },
+      {
+        threshold: 0.1,
+        rootMargin: '100px' // 하단 100px 전부터 로딩 시작
+      }
+    )
+
+    const currentTarget = observerTarget.current
+    if (currentTarget) {
+      observer.observe(currentTarget)
+      console.log('[무한스크롤] Observer 설정 완료', { hasNextPage, isFetchingNextPage })
+    }
+
+    return () => {
+      if (currentTarget) {
+        observer.unobserve(currentTarget)
+      }
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // 모든 페이지의 게시글을 하나의 배열로 합치기
+  const allPosts = data?.pages.flatMap((page) => page.content) ?? []
 
   return (
     <div className="min-h-screen bg-background">
@@ -50,8 +109,29 @@ export default function ShoppingTalkPage() {
 
       {/* Posts List */}
       <div className="mx-auto max-w-[1256px] px-4 py-8">
+        {/* Sort Options */}
+        <div className="flex gap-2 mb-6">
+          {sortOptions.map((option) => (
+            <Button
+              key={option.label}
+              variant={selectedSort.label === option.label ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedSort(option)}
+              className="text-sm"
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+
         <div className="space-y-4">
-          {talkPosts.map((post) => {
+          {isLoading && (
+            <div className="text-center py-8 text-text-secondary">
+              로딩 중...
+            </div>
+          )}
+          {allPosts.map((post: CommunityPost) => {
+            const uiPost = mapPostToUI(post)
             // 첫 번째 이미지를 썸네일로 사용
             const thumbnail = post.imagesUrl?.[0]
             // S3 URL 정리
@@ -61,31 +141,42 @@ export default function ShoppingTalkPage() {
 
             return (
               <a
-                key={post.id}
-                href={`/community/shopping-talk/${post.id}`}
+                key={uiPost.id}
+                href={`/community/shopping-talk/${uiPost.id}`}
                 className="block bg-background border border-divider rounded-lg p-6 hover:shadow-md transition-shadow cursor-pointer"
               >
                 <div className="flex items-start gap-4">
                   {/* Category Badge */}
-                  <span
-                    className={`px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap self-start ${
-                      categoryColors[post.category] || "bg-gray-100 text-gray-600"
-                    }`}
-                  >
-                    {post.category}
-                  </span>
+                  {uiPost.category && (
+                    <span
+                      className={`px-3 py-1 rounded-full text-xs font-semibold whitespace-nowrap self-start ${categoryColors[uiPost.category] || "bg-gray-100 text-gray-600"}`}
+                    >
+                      {uiPost.category}
+                    </span>
+                  )}
 
                   {/* Post Content */}
                   <div className="flex-1 min-w-0">
-                    <h2 className="text-lg font-semibold text-foreground mb-2 hover:text-primary transition-colors">
-                      {post.title}
-                    </h2>
-                    <p className="text-sm text-text-secondary line-clamp-2 mb-3">{post.content}</p>
+                    <div className="flex items-center gap-2 mb-2 flex-wrap">
+                      <h2 className="text-lg font-semibold text-foreground hover:text-primary transition-colors">
+                        {uiPost.title}
+                      </h2>
+                      {/* Auto Keywords - 제목 옆에 표시 */}
+                      {uiPost.keywords.map((keyword, idx) => (
+                        <span
+                          key={idx}
+                          className={`px-2 py-0.5 rounded-md text-xs font-medium border ${getKeywordStyle(keyword)}`}
+                        >
+                          #{keyword}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="text-sm text-text-secondary line-clamp-2 mb-3">{uiPost.content}</p>
 
                     {/* Post Meta */}
                     <div className="flex items-center gap-4 text-xs text-text-secondary">
-                      <span className="font-medium text-foreground">{post.author}</span>
-                      <span>{post.createdAt}</span>
+                      <span className="font-medium text-foreground">{uiPost.author}</span>
+                      <span>{uiPost.createdAt}</span>
                       <div className="flex items-center gap-3">
                         <span className="flex items-center gap-1">
                           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -102,7 +193,7 @@ export default function ShoppingTalkPage() {
                               d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
                             />
                           </svg>
-                          {post.views}
+                          {uiPost.views}
                         </span>
                         <span className="flex items-center gap-1">
                           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -113,7 +204,7 @@ export default function ShoppingTalkPage() {
                               d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"
                             />
                           </svg>
-                          {post.likes}
+                          {uiPost.likes}
                         </span>
                         <span className="flex items-center gap-1">
                           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -124,7 +215,7 @@ export default function ShoppingTalkPage() {
                               d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
                             />
                           </svg>
-                          {post.comments}
+                          {uiPost.comments}
                         </span>
                       </div>
                     </div>
@@ -135,7 +226,7 @@ export default function ShoppingTalkPage() {
                     <div className="flex-shrink-0 w-24 h-24 rounded-lg overflow-hidden bg-surface">
                       <img
                         src={cleanThumbnail}
-                        alt={post.title}
+                        alt={uiPost.title}
                         className="w-full h-full object-cover"
                         onError={(e) => {
                           const target = e.target as HTMLImageElement
@@ -152,6 +243,26 @@ export default function ShoppingTalkPage() {
               </a>
             )
           })}
+
+          {/* 무한 스크롤 트리거 - observer target은 항상 렌더링 */}
+          <div ref={observerTarget} className="py-8">
+            {isFetchingNextPage && (
+              <div className="text-center text-sm text-text-secondary flex items-center justify-center gap-2">
+                <div className="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full"></div>
+                더 불러오는 중...
+              </div>
+            )}
+            {!isFetchingNextPage && !hasNextPage && allPosts.length > 0 && (
+              <div className="text-center text-text-secondary text-sm">
+                모든 게시글을 불러왔습니다
+              </div>
+            )}
+            {!isLoading && allPosts.length === 0 && (
+              <div className="text-center py-12 text-text-secondary">
+                게시글이 없습니다
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { Button } from "@/components/ui/button"
 import { ProductCard } from "@/components/product-card"
 import { Heart, MessageCircle } from "lucide-react"
+import { useCommunityPosts } from '@/lib/hooks/use-community'
+import { formatRelativeTime } from '@/lib/utils'
 
 // Mock data for popular products
 const popularProducts = [
@@ -104,47 +106,25 @@ const popularProducts = [
   },
 ]
 
-// Mock data for popular shopping talk posts
-const popularShoppingTalk = [
-  {
-    id: "1",
-    category: "추천",
-    title: "10만원대 가성비 소파 추천해주세요!",
-    author: "인테리어초보",
-    comments: 45,
-    likes: 128,
-    time: "2시간 전",
-  },
-  {
-    id: "2",
-    category: "질문",
-    title: "원목 식탁 관리 어떻게 하시나요?",
-    author: "우드러버",
-    comments: 32,
-    likes: 89,
-    time: "5시간 전",
-  },
-  {
-    id: "3",
-    category: "정보",
-    title: "이번주 홈스윗홈 특가 정보 공유합니다",
-    author: "알뜰쇼퍼",
-    comments: 156,
-    likes: 423,
-    time: "1일 전",
-  },
-  {
-    id: "4",
-    category: "후기",
-    title: "북유럽 스타일 조명 구매 후기",
-    author: "조명덕후",
-    comments: 28,
-    likes: 67,
-    time: "1일 전",
-  },
-]
-
 export default function HomePage() {
+  // 🔄 인기순으로 정렬된 쇼핑수다 게시글 가져오기
+  const { data: postsData } = useCommunityPosts({
+    page: 0,
+    size: 4, // 홈페이지에는 4개만 표시
+    sort: 'likeCount', // 인기순 (좋아요 순)
+    direction: 'desc'
+  })
+
+  const popularShoppingTalk = postsData?.content.map(post => ({
+    id: post.postId.toString(),
+    category: post.category,
+    title: post.title,
+    author: post.authorName,
+    comments: post.commentCount,
+    likes: post.likeCount,
+    time: formatRelativeTime(post.createdAt),
+    thumbnail: post.imagesUrl?.[0], // 첫 번째 이미지를 썸네일로 사용
+  })) || []
   return (
     <div className="min-h-screen bg-background">
       <main>
@@ -208,36 +188,67 @@ export default function HomePage() {
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
-              {popularShoppingTalk.map((post) => (
-                <a
-                  key={post.id}
-                  href={`/community/shopping-talk/${post.id}`}
-                  className="group block rounded-lg border border-divider bg-background p-4 transition-all hover:border-primary hover:shadow-md"
-                >
-                  <div className="mb-3 flex items-center gap-2">
-                    <span className="rounded bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-                      {post.category}
-                    </span>
-                    <span className="text-xs text-text-secondary">{post.time}</span>
-                  </div>
-                  <h3 className="mb-2 text-base font-medium text-foreground group-hover:text-primary transition-colors">
-                    {post.title}
-                  </h3>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-text-secondary">{post.author}</span>
-                    <div className="flex items-center gap-3 text-sm text-text-secondary">
-                      <span className="flex items-center gap-1">
-                        <MessageCircle className="h-4 w-4" />
-                        {post.comments}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Heart className="h-4 w-4" />
-                        {post.likes}
-                      </span>
+              {popularShoppingTalk.map((post) => {
+                // S3 URL 정리
+                const cleanThumbnail = post.thumbnail ?
+                  post.thumbnail.split('/').slice(0, 4).join('/') + '/' + post.thumbnail.split('/').pop() :
+                  null
+
+                return (
+                  <a
+                    key={post.id}
+                    href={`/community/shopping-talk/${post.id}`}
+                    className="group block rounded-lg border border-divider bg-background p-4 transition-all hover:border-primary hover:shadow-md"
+                  >
+                    <div className="flex items-center gap-3">
+                      {/* 메인 콘텐츠 */}
+                      <div className="flex-1 min-w-0">
+                        <div className="mb-3 flex items-center gap-2">
+                          <span className="rounded bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+                            {post.category}
+                          </span>
+                          <span className="text-xs text-text-secondary">{post.time}</span>
+                        </div>
+                        <h3 className="mb-3 text-base font-medium text-foreground group-hover:text-primary transition-colors line-clamp-2">
+                          {post.title}
+                        </h3>
+                        <div className="flex items-center gap-4 text-sm text-text-secondary">
+                          <span>{post.author}</span>
+                          <div className="flex items-center gap-3">
+                            <span className="flex items-center gap-1">
+                              <MessageCircle className="h-4 w-4" />
+                              {post.comments}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <Heart className="h-4 w-4" />
+                              {post.likes}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* 썸네일 이미지 */}
+                      {cleanThumbnail && (
+                        <div className="flex-shrink-0 w-20 h-20 rounded-lg overflow-hidden bg-surface">
+                          <img
+                            src={cleanThumbnail}
+                            alt={post.title}
+                            className="w-full h-full object-cover"
+                            onError={(e) => {
+                              const target = e.target as HTMLImageElement
+                              if (target.src !== post.thumbnail) {
+                                target.src = post.thumbnail!
+                              } else {
+                                target.style.display = 'none'
+                              }
+                            }}
+                          />
+                        </div>
+                      )}
                     </div>
-                  </div>
-                </a>
-              ))}
+                  </a>
+                )
+              })}
             </div>
           </div>
         </section>


### PR DESCRIPTION
- 쇼핑수다 페이지에 무한 스크롤 기능 추가
- 정렬 옵션 추가 (최신순/조회수순/인기순)
- 게시글 썸네일 이미지 표시 구현
- 자동 키워드 추출 및 태그 표시 기능 추가
- 홈페이지 인기 쇼핑수다 섹션을 실제 API 데이터로 연동
- 인기순 정렬로 실시간 인기 게시글 표시
- 썸네일 이미지를 포함한 카드 레이아웃 개선

## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

### 스크린샷 (선택)
<img width="1341" height="713" alt="image" src="https://github.com/user-attachments/assets/83d49ec3-80b6-4cad-89ce-d05c6d7392f9" />
<img width="1472" height="781" alt="image" src="https://github.com/user-attachments/assets/1a18cdc7-a743-4ade-b75a-1f8d6a1c8866" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## #️⃣닫을 이슈

<!-- 닫을 이슈 번호를 입력해주세요. -->

close #이슈번호