### PR TITLE
refactor/49: 장바구니, 결제, 주문 상세 수정

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -205,30 +205,22 @@ const filteredOrders = myOrders
       
       const orderForModal: OrderDetail = {
         id: backendData.orderId,
-        orderNumber: backendData.orderNumber,
-        orderDate: backendData.orderDate,
-        
-        // --- (수정) 백엔드 DTO의 실제 상태값으로 status/statusText 생성 ---
-        status: backendData.deliveryStatus, 
-        statusText: getStatusText(backendData.orderStatus, backendData.deliveryStatus),
-        
-        // --- (수정) 백엔드 데이터로 채우기 ---
-        customerName: backendData.customerName,
-        customerPhone: backendData.customerPhone,
-        customerEmail: backendData.customerEmail,
-        shippingAddress: backendData.shippingAddress,
-        detailAddress: "", // (백엔드 DTO에 detailAddress가 없으므로 빈 값 처리)
-        paymentMethod: backendData.paymentMethod,
-        pointsUsed: backendData.usedPoint,
-        
-        // --- (수정) 첫 번째 아이템 정보로 모달 채우기 (임시) ---
-        productName: firstItem?.productName || "상품 정보 없음",
-        productImage: firstItem?.productImage || "/placeholder.svg",
-        price: backendData.totalAmount, // (모달 UI와 협의 필요 - 상품금액? 총결제금액?)
-        option: firstItem?.optionName || "-",
-        quantity: firstItem?.quantity || 0,
-        shippingFee: backendData.totalShippingPrice, // 상품별 배송비가 아닌 총 배송비로 우선 대체
-        sellerName: firstItem?.sellerName || "-",
+      orderNumber: backendData.orderNumber,
+      orderDate: backendData.orderDate,
+      status: backendData.deliveryStatus, 
+      statusText: getStatusText(backendData.orderStatus, backendData.deliveryStatus),
+      customerName: backendData.customerName,
+      customerPhone: backendData.customerPhone,
+      customerEmail: backendData.customerEmail,
+      shippingAddress: backendData.shippingAddress,
+      detailAddress: "", // (필요시 백엔드 DTO에 추가)
+      paymentMethod: backendData.paymentMethod,
+      pointsUsed: backendData.usedPoint,
+
+      orderItems: backendData.orderItems, // ★★★ 'orderItems' 배열 통째로 전달 ★★★
+
+      totalAmount: backendData.totalAmount,
+      totalShippingPrice: backendData.totalShippingPrice,
       };
 
       setSelectedOrder(orderForModal); // 3. 상태 저장
@@ -490,72 +482,86 @@ const filteredOrders = myOrders
 
               {/* Order Product */}
               <div className="border border-divider rounded-lg p-4 space-y-3">
-                <h3 className="font-semibold text-foreground text-lg mb-3">주문 상품</h3>
-                <div className="flex gap-4">
-                  <img
-                    src={selectedOrder.productImage || "/placeholder.svg"}
-                    alt={selectedOrder.productName}
-                    className="w-24 h-24 object-cover rounded-lg"
-                  />
-                  <div className="flex-1 space-y-2">
-                    <h4 className="font-semibold text-foreground">{selectedOrder.productName}</h4>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div>
-                        <p className="text-text-secondary">옵션</p>
-                        <p className="text-foreground font-medium">{selectedOrder.option}</p>
-                      </div>
-                      <div>
-                        <p className="text-text-secondary">수량</p>
-                        <p className="text-foreground font-medium">{selectedOrder.quantity}개</p>
-                      </div>
-                      <div>
-                        <p className="text-text-secondary">배송비</p>
-                        <p className="text-foreground font-medium">
-                          {selectedOrder.shippingFee === 0 ? "무료" : `${selectedOrder.shippingFee.toLocaleString()}원`}
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-text-secondary">판매자</p>
-                        <p className="text-foreground font-medium">{selectedOrder.sellerName}</p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+      <h3 className="font-semibold text-foreground text-lg mb-3">주문 상품</h3>
+
+      {/* ★ selectedOrder.orderItems 배열을 map으로 순회 ★ */}
+      {selectedOrder.orderItems.map((item) => (
+        <div key={item.orderItemId} className="flex gap-4 pb-4 border-b last:border-b-0">
+          <img
+            src={item.productImage || "/placeholder.svg"}
+            alt={item.productName}
+            className="w-24 h-24 object-cover rounded-lg"
+          />
+          <div className="flex-1 space-y-2">
+            <h4 className="font-semibold text-foreground">{item.productName}</h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div>
+                <p className="text-text-secondary">옵션</p>
+                <p className="text-foreground font-medium">{item.optionName}</p>
               </div>
+              <div>
+                <p className="text-text-secondary">수량</p>
+                <p className="text-foreground font-medium">{item.quantity}개</p>
+              </div>
+              <div>
+                <p className="text-text-secondary">배송비</p>
+                <p className="text-foreground font-medium">
+                  {item.shippingFee === 0 ? "무료" : `${item.shippingFee.toLocaleString()}원`}
+                </p>
+              </div>
+              <div>
+                <p className="text-text-secondary">판매자</p>
+                <p className="text-foreground font-medium">{item.sellerName}</p>
+              </div>
+               <div>
+                <p className="text-text-secondary">상품 금액</p>
+                <p className="text-foreground font-medium">
+                  {(item.price * item.quantity).toLocaleString()}원
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
 
               {/* Payment Information */}
               <div className="border border-divider rounded-lg p-4 space-y-3">
-                <h3 className="font-semibold text-foreground text-lg mb-3">결제 정보</h3>
-                <div className="space-y-2">
-                  <div className="flex justify-between text-sm">
-                    <span className="text-text-secondary">상품 금액</span>
-                    <span className="text-foreground font-medium">{selectedOrder.price.toLocaleString()}원</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span className="text-text-secondary">배송비</span>
-                    <span className="text-foreground font-medium">
-                      {selectedOrder.shippingFee === 0 ? "무료" : `${selectedOrder.shippingFee.toLocaleString()}원`}
-                    </span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span className="text-text-secondary">포인트 사용</span>
-                    <span className="text-red-600 font-medium">-{selectedOrder.pointsUsed.toLocaleString()}P</span>
-                  </div>
-                  <div className="border-t border-divider pt-2 mt-2">
-                    <div className="flex justify-between">
-                      <span className="font-semibold text-foreground">최종 결제 금액</span>
-                      <span className="text-xl font-bold text-primary">
-                        {(selectedOrder.price + selectedOrder.shippingFee - selectedOrder.pointsUsed).toLocaleString()}
-                        원
-                      </span>
-                    </div>
-                  </div>
-                  <div className="flex justify-between text-sm pt-2">
-                    <span className="text-text-secondary">결제 수단</span>
-                    <span className="text-foreground font-medium">{selectedOrder.paymentMethod}</span>
-                  </div>
-                </div>
-              </div>
+      <h3 className="font-semibold text-foreground text-lg mb-3">결제 정보</h3>
+      <div className="space-y-2">
+
+        {/* (상품 금액, 배송비 - DTO 구조에 따라 totalAmount/totalShippingPrice로 대체) */}
+        <div className="flex justify-between text-sm">
+          <span className="text-text-secondary">총 상품 금액</span>
+          {/* (totalAmount - totalShippingPrice로 계산) */}
+          <span className="text-foreground font-medium">
+            {(selectedOrder.totalAmount - selectedOrder.totalShippingPrice).toLocaleString()}원
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-text-secondary">총 배송비</span>
+          <span className="text-foreground font-medium">
+            {selectedOrder.totalShippingPrice === 0 ? "무료" : `${selectedOrder.totalShippingPrice.toLocaleString()}원`}
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-text-secondary">포인트 사용</span>
+          <span className="text-red-600 font-medium">-{selectedOrder.pointsUsed.toLocaleString()}P</span>
+        </div>
+        <div className="border-t border-divider pt-2 mt-2">
+          <div className="flex justify-between">
+            <span className="font-semibold text-foreground">최종 결제 금액</span>
+            <span className="text-xl font-bold text-primary">
+              {selectedOrder.totalAmount.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+        <div className="flex justify-between text-sm pt-2">
+          <span className="text-text-secondary">결제 수단</span>
+          <span className="text-foreground font-medium">{selectedOrder.paymentMethod}</span>
+        </div>
+      </div>
+    </div>
             </div>
           )}
 

--- a/app/profile/shopping-section.tsx
+++ b/app/profile/shopping-section.tsx
@@ -61,7 +61,7 @@ export const ShoppingSection: React.FC<ShoppingSectionProps> = ({
               </svg>
             </div>
             <div>
-              <p className="text-sm text-white/80 mb-1">보유 포인트</p>
+              <p className="text-sm text-white/80 mb-1">보유 포인트(아직 기능 없음)</p>
               <p className="text-3xl font-bold">{userPoints.toLocaleString()}P</p>
             </div>
           </div>
@@ -135,9 +135,9 @@ export const ShoppingSection: React.FC<ShoppingSectionProps> = ({
                   </Button>
                   {order.status === "delivered" && (
                     <>
-                    <Button variant="outline" size="sm">
+                    {/* <Button variant="outline" size="sm">
                       리뷰 작성
-                    </Button>
+                    </Button> */}
                     <Button
                     variant="ghost"
                     size="sm"

--- a/lib/api/cart.ts
+++ b/lib/api/cart.ts
@@ -54,3 +54,11 @@ export const deleteCartItems = async (cartItemIds: number[]): Promise<void> => {
 export const clearCart = async (): Promise<ApiResponse<void>> => {
   return await apiClient.delete(CART_ENDPOINTS.CLEAR_CART)
 }
+
+/**
+ * 장바구니 항목 수량 변경 
+ */
+export const updateCartItemQuantity = async (cartId: string, quantity: number) => {
+  const response = await apiClient.patch(`/api/v1/carts/${cartId}`, { quantity });
+  return response.data; // (백엔드 응답이 있다면 반환)
+}

--- a/lib/hooks/use-cart.ts
+++ b/lib/hooks/use-cart.ts
@@ -8,7 +8,8 @@ import {
   getCartItems, 
   deleteCartItem, 
   deleteCartItems, 
-  clearCart 
+  clearCart,
+  updateCartItemQuantity
 } from '@/lib/api/cart'
 import { CartRequest, Cart, CartResponse } from '@/types/api/cart'
 import { ScrollResponse } from '@/types/api/common'
@@ -122,4 +123,27 @@ export const useClearCart = () => {
       queryClient.invalidateQueries({ queryKey: CART_QUERY_KEYS.list() })
     },
   })
+}
+
+/**
+ * 장바구니 아이템 수량 변경 훅
+ */
+export const useUpdateCartQuantity = () => {
+  const queryClient = useQueryClient();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useMutation<any, Error, { cartId: string; quantity: number }>({
+    mutationFn: ({ cartId, quantity }) => { // cartId와 quantity를 객체로 받음
+      if (!isAuthenticated) {
+        throw new Error('로그인이 필요합니다.');
+      }
+      // 1단계에서 만든 API 함수 호출
+      return updateCartItemQuantity(cartId, quantity); 
+    },
+    onSuccess: () => {
+      // 성공 시 장바구니 목록 쿼리를 무효화하여 새로고침 (깜빡임 발생)
+      // TODO: Optimistic Update로 개선 가능
+      queryClient.invalidateQueries({ queryKey: CART_QUERY_KEYS.list() });
+    },
+  });
 }

--- a/stores/checkout-store.ts
+++ b/stores/checkout-store.ts
@@ -1,0 +1,24 @@
+// stores/checkout-store.ts
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { CartResponse } from '@/types/order'; // CartResponse 타입을 재사용
+
+type CheckoutStore = {
+  items: CartResponse[];
+  setItems: (items: CartResponse[]) => void;
+  clearItems: () => void;
+}
+
+export const useCheckoutStore = create<CheckoutStore>()(
+  persist(
+    (set) => ({
+      items: [],
+      setItems: (items) => set({ items }),
+      clearItems: () => set({ items: [] }),
+    }),
+    { 
+      name: 'checkout-storage', // 세션 스토리지에 저장될 키 이름
+      storage: createJSONStorage(() => sessionStorage), // localStorage 대신 sessionStorage 사용
+    }
+  )
+);

--- a/types/order.tsx
+++ b/types/order.tsx
@@ -81,27 +81,24 @@ export interface MyOrder {
   
   // 주문 상세 모달용
 export type OrderDetail = {
-    id: number
-    orderNumber: string
-    productName: string
-    productImage: string
-    price: number
-    orderDate: string
-    status: string // 예: "delivered", "shipping"
-    statusText: string // 예: "배송 완료", "배송 중"
+    id: number; // (수정) orderId
+    orderNumber: string;
+    orderDate: string;
+    status: string; // (수정) deliveryStatus
+    statusText: string;
     
-    // --- 상세 필드들 ---
-    customerName: string
-    customerPhone: string
-    customerEmail: string
-    shippingAddress: string
-    detailAddress: string
-    option: string
-    quantity: number
-    shippingFee: number
-    sellerName: string
-    pointsUsed: number
-    paymentMethod: string
+    customerName: string;
+    customerPhone: string;
+    customerEmail: string;
+    shippingAddress: string;
+    detailAddress: string; // (백엔드 DTO에 없으면 옵셔널 '?' 또는 빈 값 처리)
+    pointsUsed: number;
+    paymentMethod: string;
+
+    orderItems: OrderDetailItemResponse[];
+    
+    totalAmount: number; // 최종 결제 금액
+    totalShippingPrice: number; // 총 배송비
   }
 
 export interface OrderDetailItemResponse {


### PR DESCRIPTION
## 📝 PR 유형

<!-- 해당하는 유형에 'x'로 체크해주세요. -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 문서 작업 (Documentation)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 📝작업 내용
1. 제품 상세 페이지에서 옵션을 선택하지 않고 구매하기를 누르면 주문 생성이 거절되고 옵션을 선택하고 구매하면 주문 생성 되어, 장바구니 구매와 제품 페이지 구매 분기를 나눕니다.
2. 장바구니를 통해 결제 페이지에서 두 건이상의 주문을 넣어도 처음 넣은 대표 상품 한 건만 보이는 것을 모든 제품이 다 나오게 하였습니다.
3. 주문 상세 보기에서 두 가지 상품을 구매하면 마지막에 담은 제품 하나만 나온것을 모든 제품이 다 나오게 하였습니다.
4. 장바구니 페이지에서 수량을 변경하면 주문 목록이 위로 올라가고, 수량이 변경 될 때 마다 화면이 깜빡이는 것을 새로운 API를 만들어 주문 상품이 수량 변경을 하여도 제자리에 고정되고 화면 깜빡임을 없앴습니다.

## #️⃣닫을 이슈

close #49 